### PR TITLE
Edit Page for UCSBDiningCommonsMenuItem plus tests and stories

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
@@ -1,13 +1,70 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemEditPage() {
+export default function UCSBDiningCommonsMenuItemsEditPage({storybook=false}) {
+  let { id } = useParams();
 
-  // Stryker disable all : placeholder for future implementation
+  const { data: ucsbDiningCommonsMenuItem, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/UCSBDiningCommonsMenuItem?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/UCSBDiningCommonsMenuItem`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (ucsbDiningCommonsMenuItem) => ({
+    url: "/api/UCSBDiningCommonsMenuItem",
+    method: "PUT",
+    params: {
+      id: ucsbDiningCommonsMenuItem.id,
+    },
+    data: {
+      diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+      name: ucsbDiningCommonsMenuItem.name,
+      station: ucsbDiningCommonsMenuItem.station
+    }
+  });
+
+  const onSuccess = (ucsbDiningCommonsMenuItem) => {
+    toast(`UCSBDiningCommonsMenuItem Updated - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/UCSBDiningCommonsMenuItem?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit UCSBDiningCommonsMenuItem</h1>
+        {
+          ucsbDiningCommonsMenuItem && <UCSBDiningCommonsMenuItemForm initialContents={ucsbDiningCommonsMenuItem} submitAction={onSubmit} buttonLabel="Update" />
+        }
       </div>
     </BasicLayout>
   )
 }
+

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
@@ -1,0 +1,38 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+
+export default {
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage',
+    component: UCSBDiningCommonsMenuItemEditPage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/UCSBDiningCommonsMenuItem', (_req, res, ctx) => {
+            return res(ctx.json(ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems[0]));
+        }),
+        rest.put('/api/UCSBDiningCommonsMenuItem', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}
+
+
+

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
@@ -1,44 +1,176 @@
-import { render, screen } from "@testing-library/react";
-import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    describe("when the backend doesn't return data", () => {
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } }).timeout();
+        });
 
-        setupUserOnly();
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <UCSBDiningCommonsMenuItemEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+            const restoreConsole = mockConsole();
 
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit UCSBDiningCommonsMenuItem");
+            expect(screen.queryByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode")).not.toBeInTheDocument();
+            restoreConsole();
+        });
     });
 
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                diningCommonsCode: "Ortega",
+                name: "Gyro",
+                station: "Euro"
+            });
+            axiosMock.onPut('/api/UCSBDiningCommonsMenuItem').reply(200, {
+                id: 17,
+                diningCommonsCode: "Portola",
+                name: "Sushi",
+                station: "Asia"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+
+            const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+            const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+            const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+            const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+            const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(diningCommonsCodeField).toHaveValue("Ortega");
+            expect(nameField).toHaveValue("Gyro");
+            expect(stationField).toHaveValue("Euro");
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+
+            const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+            const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+            const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+            const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+            const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(diningCommonsCodeField).toHaveValue("Ortega");
+            expect(nameField).toHaveValue("Gyro");
+            expect(stationField).toHaveValue("Euro");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(diningCommonsCodeField, { target: { value: 'Portola' } })
+            fireEvent.change(nameField, { target: { value: 'Sushi' } })
+            fireEvent.change(stationField, { target: { value: "Asia" } })
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("UCSBDiningCommonsMenuItem Updated - id: 17 name: Sushi");
+            expect(mockNavigate).toBeCalledWith({ "to": "/diningcommonsmenuitem" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                diningCommonsCode: "Portola",
+                name: "Sushi",
+                station: "Asia"
+            })); // posted object
+
+        });
+
+       
+    });
 });
 
 


### PR DESCRIPTION
When the user navigates to /diningcommonsmenuitem/edit/:id where :id
is the id field of a valid record in the table, the page will be populated
with data from that row of the database, and will be able to edit fields
from that database record.

Valid changes made on the page are saved to the database when the user clicks
the submit button.

Changes made on the page are NOT saved when the page contains invalid data; instead,
appropriate error messages are shown.

Changes made on the page are NOT saved when the user clicks the cancel button,
and the user is routed back to the previous page they were on (like the "back button").
<img width="981" alt="image" src="https://github.com/ucsb-cs156-w24/team03-w24-5pm-1/assets/91820969/67cfef81-c942-4c9c-8b27-b6f202bfc570">
closes #15